### PR TITLE
build(lefthook): use yarn

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,8 +18,8 @@ pre-commit:
     eslint:
       root: "frontend"
       glob: "*.{js,ts,vue}"
-      run: docker-compose run --rm nuxt npx eslint {staged_files}
+      run: docker-compose run --rm nuxt yarn eslint {staged_files}
     prettier:
       root: "frontend"
       glob: "*.{js,ts,vue}"
-      run: docker-compose run --rm nuxt npx prettier --check {staged_files}
+      run: docker-compose run --rm nuxt yarn prettier --check {staged_files}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **チョア**
  - ESLintとPrettierのコマンドを`npx`から`yarn`に変更してDockerコンテナ内で実行するように更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->