### PR TITLE
refactor(github-actions): change job name

### DIFF
--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 permissions: write-all
 jobs:
-  lint:
+  lint-dockerfile:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -13,7 +13,7 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  lint:
+  lint-frontend:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `.github/workflows/lint-dockerfile.yml`のジョブ名を`lint`から`lint-dockerfile`に変更。
  - `.github/workflows/lint-frontend.yml`のジョブ名を`lint`から`lint-frontend`に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->