### PR TITLE
ci(github-actions): change hadolint job name

### DIFF
--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 permissions: write-all
 jobs:
-  lint:
+  hadolint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `.github/workflows/lint-dockerfile.yml` のジョブ名を `lint` から `hadolint` に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->