### PR TITLE
chore: fix typo

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,6 +23,6 @@ pre-commit:
       root: "frontend"
       glob: "*.{js,ts,vue}"
       run: docker-compose run --rm nuxt yarn prettier --check {staged_files}
-    hadlint:
+    hadolint:
       glob: "**/Dockerfile"
       run: hadolint {staged_files}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **チョア**
  - `lefthook.yml`内の`pre-commit`タスク名を`hadlint`から`hadolint`に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->