### PR TITLE
refactor: rename lint-docker

### DIFF
--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -1,6 +1,6 @@
 ---
 
-name: lint-dockerfile
+name: lint-docker
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Lint Dockerfile
+      - name: hadolint
         uses: hadolint/hadolint-action@master
         with:
           dockerfile: 'Dockerfile'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - ワークフロー名を `lint-dockerfile` から `lint-docker` に変更。
  - アクション名を `Lint Dockerfile` から `hadolint` に更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->