### PR TITLE
fix(eslint): disable no-require-imports

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -11,5 +11,6 @@ export default {
   theme: {
     extend: {},
   },
+  /* eslint-disable @typescript-eslint/no-require-imports */
   plugins: [require("daisyui")],
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,11 +19,11 @@ pre-commit:
     eslint:
       root: "frontend"
       glob: "*.{js,ts,vue}"
-      run: docker-compose run --rm nuxt yarn eslint {staged_files}
+      run: docker compose run --rm nuxt yarn eslint {staged_files}
     prettier:
       root: "frontend"
       glob: "*.{js,ts,vue}"
-      run: docker-compose run --rm nuxt yarn prettier --check {staged_files}
+      run: docker compose run --rm nuxt yarn prettier --check {staged_files}
     hadolint:
       glob: "**/Dockerfile"
       run: hadolint {staged_files}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - ESLintルールの無効化に関するコメントをTailwind CSSの設定ファイルに追加しました。
  - Docker関連の操作のコマンド構文を更新し、`docker-compose`を`docker compose`に置き換えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->