### PR TITLE
chore: disable MD029 rule

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,3 +6,5 @@ MD013: false
 
 MD024:
   siblings_only: true
+
+MD029: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新規機能
  - なし
- 雑務
  - MarkdownのLint設定を更新し、MD029（番号付きリストの接頭辞）を無効化。既存のMD013無効化とMD024のsiblings_only設定は維持。アプリの機能・表示・動作への影響はありません。パフォーマンスや互換性にも変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->