### PR TITLE
chore: disable document-start rule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,5 +3,6 @@
 extends: default
 
 rules:
+  document-start: disable
   line-length: disable
   truthy: disable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - YAML のリンティング設定を更新し、document-start チェックを無効化しました。これにより、YAML ファイル先頭のドキュメント区切り（例: "---"）が必須ではなくなり、開発時の警告が減少します。動作や機能への影響はなく、開発体験の改善を目的とした調整です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->