### PR TITLE
fix: restrict workflow permissions

### DIFF
--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -2,7 +2,8 @@ name: lint-docker
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-permissions: write-all
+permissions:
+  contents: read
 jobs:
   hadolint:
     runs-on: ubuntu-latest

--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -6,7 +6,9 @@ run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
-permissions: write-all
+permissions:
+  pull-requests: write
+  issues: write
 jobs:
   call-preset-pr:
     uses: jnicrimi/reusable-workflows/.github/workflows/called-preset-pr.yml@main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - Docker 用リンターのワークフローで、リポジトリ権限を「contents: read」に限定。
  - PR プリセットのワークフローで、権限を「pull-requests: write」「issues: write」のみに絞り込み。
  - 既存のトリガーやジョブ、ステップの挙動に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->