### PR TITLE
chore: simplify editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,24 +4,10 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = unset
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.js]
-indent_size = 2
-
-[*.json]
-indent_size = 2
-
 [*.md]
+indent_size = unset
 trim_trailing_whitespace = false
-
-[*.ts]
-indent_size = 2
-
-[*.vue]
-indent_size = 2
-
-[*.{yml,yaml}]
-indent_size = 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* スタイル
  * .editorconfig を整理し、既定のインデントを 2 スペースに統一してフォーマットのばらつきを低減。
  * Markdown はインデントサイズ指定を解除し、trim_trailing_whitespace=false は維持して意図した改行を保持。
  * 言語別セクション（JS/JSON/TS/Vue/YAML）を削除し、設定を簡素化して一貫性を向上。

* チョア
  * エディタ設定のメンテナンス性を改善し、プロジェクト全体で安定したコードスタイル適用を促進。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->