### PR TITLE
chore: reorder commitlint types

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,17 +6,18 @@ module.exports = {
       [
         'feat',
         'fix',
-        'docs',
-        'style',
         'refactor',
+        'docs',
         'test',
-        'chore',
+        'style',
         'build',
         'ci',
-        'revert',
-      ],
+        'perf',
+        'chore',
+        'revert'
+      ]
     ],
     'type-empty': [2, 'never'],
-    'subject-empty': [2, 'never'],
-  },
+    'subject-empty': [2, 'never']
+  }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - コミットメッセージの許可タイプに「perf」を追加し、タイプの並び順を整理しました。これにより、パフォーマンス関連の変更を明確に区別できます。
  - 既存ルールの意味は変更していません（subject-empty は従来どおり）。
  - 本変更によるアプリ機能・UI・挙動への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->