### PR TITLE
fix: correct docker port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,11 @@ services:
       - ./frontend:/app:cached
       - node_modules:/app/node_modules
     ports:
-      - "80:3000"
+      - "3000:3000"
       - "24678:24678"
     tty: true
     environment:
       - HOST=0.0.0.0
-      - port=80
       - CHOKIDAR_USEPOLLING=true
       - COMPOSE_PROJECT_NAME=portfolio
 volumes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境の公開ポートを80→3000に変更。以後のアクセス先は http://localhost:3000 です。
  * Nuxt サービスの環境変数 port=80 を削除。コンテナ内部ポートは引き続き3000のままです。
  * これまでポート80を前提とした手順やリバースプロキシ設定を利用している場合は、必要に応じて3000向けに更新してください。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->