### PR TITLE
chore: remove run-name from workflows

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -2,7 +2,6 @@ name: lint-frontend
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -2,7 +2,6 @@ name: preset-pr
 on:
   pull_request:
     types: [opened, reopened]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * CIのワークフローから実行名(run-name)の明示指定を削除し、デフォルト命名に統一しました（フロントエンドのLintとPRプリセットのワークフローが対象）。
  * 実行履歴の表示名が変更されますが、トリガー、並行実行、権限、ジョブやステップの内容は従来どおりです。
  * アプリの機能やUIへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->