### PR TITLE
chore: tune renovate release age and add vuln alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "timezone": "Asia/Tokyo",
   "schedule": ["after 10am and before 1pm on saturday"],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": ["npm"],
@@ -12,7 +12,11 @@
     },
     {
       "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "14 days"
+      "minimumReleaseAge": "7 days"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "labels": ["security"]
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（保守作業）**
  * 依存パッケージの自動更新タイミングを短縮しました。標準更新は3日、メジャー更新は7日で対応可能になります。セキュリティアラートはリリース直後から即座に検出・適用できるよう設定されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->