### PR TITLE
fix(renovate): skip tailwindcss 4.2.3/4.2.4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/vite"],
+      "allowedVersions": "<4.2.3 || >=4.2.5",
+      "description": "Skip 4.2.3/4.2.4 due to @plugin .css regression (tailwindlabs/tailwindcss#19950). Remove this rule once 4.2.5+ is released and the pin in frontend/package.json pnpm.overrides is lifted."
+    },
+    {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm dependencies"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * Tailwind CSS関連の依存関係の自動更新ルールを調整し、特定のバージョンを除外する設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->